### PR TITLE
fix() : ignore empty parameters of strategies in generated json files

### DIFF
--- a/src/main/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDsl.kt
+++ b/src/main/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDsl.kt
@@ -66,9 +66,9 @@ class ChutneyScenarioBuilder(val id: Int? = null, val title: String = "") {
     }
 
     fun build(): ChutneyScenario = ChutneyScenario(id, title, description, givens, `when`, thens)
-
 }
 
+@JsonInclude(NON_EMPTY)
 open class Strategy(val type: String, val parameters: Map<String, String> = emptyMap())
 open class RetryTimeOutStrategy(timeout: String, retryDelay: String) :
     Strategy(type = "retry-with-timeout", parameters = mapOf("timeOut" to timeout, "retryDelay" to retryDelay))

--- a/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
+++ b/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
@@ -69,7 +69,7 @@ class ChutneyScenarioDslTest {
     }
 
     @Test
-    fun `abe to create chutney scenario using kotlin dsl with functions and multiple assertions`() {
+    fun `able to create chutney scenario using kotlin dsl with functions and multiple assertions`() {
 
         fun declareUri(): ChutneyStepBuilder.() -> Unit = { ContextPutTask(entries = mapOf("uri" to "api/people/1")) }
 
@@ -91,7 +91,7 @@ class ChutneyScenarioDslTest {
     }
 
     @Test
-    fun `abe to create chutney scenario using kotlin dsl with extension functions`() {
+    fun `able to create chutney scenario using kotlin dsl with extension functions`() {
 
         fun ChutneyStepBuilder.declareUri() = ContextPutTask(entries = mapOf("uri" to "api/people/1"))
 
@@ -112,7 +112,7 @@ class ChutneyScenarioDslTest {
     }
 
     @Test
-    fun `abe to create chutney scenario using kotlin dsl with softAssertions`() {
+    fun `able to create chutney scenario using kotlin dsl with softAssertions`() {
 
         fun declareUri(): ChutneyStepBuilder.() -> Unit = { ContextPutTask(entries = mapOf("uri" to "api/people/1")) }
 

--- a/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
+++ b/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class ChutneyScenarioDslTest {
 
     @Test
-    fun `abe to create chutney scenario using kotlin dsl`() {
+    fun `able to create chutney scenario using kotlin dsl`() {
 
         val `swapi GET people record` = Scenario(title = "swapi GET people record") {
             Given("I set get people service api endpoint") {
@@ -108,6 +108,29 @@ class ChutneyScenarioDslTest {
         }
 
         "$`swapi GET people record`" `should strictly equal json` "/get-people.chutney.json".asResource()
+
+    }
+
+    @Test
+    fun `abe to create chutney scenario using kotlin dsl with softAssertions`() {
+
+        fun declareUri(): ChutneyStepBuilder.() -> Unit = { ContextPutTask(entries = mapOf("uri" to "api/people/1")) }
+
+        val `swapi GET people record` = Scenario(title = "swapi GET people record") {
+            Given("I set get people service api endpoint", declareUri())
+            When("I send GET HTTP request") {
+                HttpGetTask(target = "swapi.dev", uri = "uri".spEL())
+            }
+            Then("I receive valid HTTP response", strategy = SoftAssertStrategy()) {
+                JsonAssertTask(
+                    document = "body".spEL(),
+                    expected = mapOf("$.name" to "Luke Skywalker", "$.species" to emptyArray<String>())
+                )
+            }
+        }
+
+        // create this file get-people-multiple-assertions-soft-strategy.chutney.json
+        "$`swapi GET people record`" `should equal json` "/get-people-multiple-assertions-soft-strategy.chutney.json".asResource()
 
     }
 

--- a/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
+++ b/src/test/kotlin/com/chutneytesting/kotlin/dsl/ChutneyScenarioDslTest.kt
@@ -50,7 +50,7 @@ class ChutneyScenarioDslTest {
     }
 
     @Test
-    fun `abe to create chutney scenario using kotlin dsl with functions`() {
+    fun `able to create chutney scenario using kotlin dsl with functions`() {
 
         fun declareUri(): ChutneyStepBuilder.() -> Unit = { ContextPutTask(entries = mapOf("uri" to "api/people/1")) }
 

--- a/src/test/resources/get-people-multiple-assertions-soft-strategy.chutney.json
+++ b/src/test/resources/get-people-multiple-assertions-soft-strategy.chutney.json
@@ -1,0 +1,46 @@
+{
+    "title": "swapi GET people record",
+    "description": "swapi GET people record",
+    "givens": [
+        {
+            "description": "I set get people service api endpoint",
+            "implementation": {
+                "type": "context-put",
+                "inputs": {
+                    "entries": {
+                        "uri": "api/people/1"
+                    }
+                }
+            }
+        }
+    ],
+    "when": {
+        "description": "I send GET HTTP request",
+        "implementation": {
+            "type": "http-get",
+            "target": "swapi.dev",
+            "inputs": {
+                "uri": "${#uri}",
+                "timeout" : "2 sec"
+            }
+        }
+    },
+    "thens": [
+        {
+            "strategy": {
+                "type": "soft-assert"
+            },
+            "description": "I receive valid HTTP response",
+            "implementation": {
+                "type": "json-assert",
+                "inputs": {
+                    "document": "${#body}",
+                    "expected": {
+                        "$.name": "Luke Skywalker",
+                        "$.species": []
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
ignore  the empty parameters in strategies while generating json files